### PR TITLE
Fix "google_compute_target_pool.workers: Cannot determine region"

### DIFF
--- a/workers/target_pool.tf
+++ b/workers/target_pool.tf
@@ -1,6 +1,7 @@
 # Target pool for TCP/UDP load balancing
 resource "google_compute_target_pool" "workers" {
   name             = "${var.name}-worker-pool"
+  region           = "${var.region}"
   session_affinity = "NONE"
 
   health_checks = [


### PR DESCRIPTION
If no region is set at the Google provider level, Terraform fails to create the `google_compute_target_pool.workers` resource and complains with "Cannot determine region: set in this resource, or set provider-level 'region' or 'zone'."

This commit fixes the issue by explicitly setting the region for the google_compute_target_pool.workers resource.